### PR TITLE
Fix keyboard navigation after click event (#14)

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var document = require('global/document');
+var window = require('global/window');
 var EventEmitter = require('eventemitter3');
 
 var finder = require('../index');
@@ -9,6 +10,12 @@ var finder = require('../index');
 
 // for setting document.location.href
 document.location = {};
+
+// for scrolling the window
+window.pageXOffset = 0;
+window.pageYOffset = 0;
+window.scrollTo = function (x, y) { }; // eslint-disable-line
+
 
 test('[finder] finder', function test(t) {
   var children = [{
@@ -135,6 +142,7 @@ test('[finder] itemSelected', function test(t) {
   };
   var emitter = new EventEmitter();
   var col = document.createElement('div');
+  var container = document.createElement('div');
   var value = {
     item: {
       _item: {
@@ -147,7 +155,8 @@ test('[finder] itemSelected', function test(t) {
         }]
       }
     },
-    col: col
+    col: col,
+    container: container
   };
 
   // test plan is to verify the column-created event is emitted
@@ -184,6 +193,7 @@ test('[finder] clickEvent', function test(t) {
   var emitter = new EventEmitter();
   var item = document.createElement('li');
   var col = document.createElement('div');
+  var container = document.createElement('div');
   var event;
 
   col.className = cfg.className.col;
@@ -196,17 +206,17 @@ test('[finder] clickEvent', function test(t) {
   };
 
   t.plan(2);
-  finder.clickEvent(cfg, emitter, event);
+  finder.clickEvent(container, cfg, emitter, event);
 
   emitter.on('item-selected', t.ok.bind(null, true, 'item clicked'));
-  finder.clickEvent(cfg, emitter, event);
+  finder.clickEvent(container, cfg, emitter, event);
 
   item.className = cfg.className.item + ' ' + cfg.className.active;
-  finder.clickEvent(cfg, emitter, event);
+  finder.clickEvent(container, cfg, emitter, event);
 
   // non-listitem clicked
   item.className = '';
-  finder.clickEvent(cfg, emitter, event);
+  finder.clickEvent(container, cfg, emitter, event);
 
   t.end();
 });


### PR DESCRIPTION
#14 describes an interesting problem, wherein after clicking on an item, then using the keyboard to navigate left, keyboard navigation no longer works, and the cursor keys scroll the page.

I believe what is happening is that when you click on an item, focus is being given to the `<a>` element. Then, when you press the left arrow, the column containing the focused `<a>` element is destroyed and rebuilt. Some browsers, including Safari and Chrome, seem to revert keydown events back to the document (or window?) if the active element no longer exists.

The fix is to make sure that focus is always on an existing element; I've decided to give focus to the container after each `item-selected` event.

Because the browser will scroll the viewport so that the focused element is in view, this would result in a jump when an item is selected. The workaround is to save the scroll position before focusing, and then restore it. However, note that I'm doing this in the most standards-compliant way, but there are [more complex methods](https://stackoverflow.com/a/16419785/145504) that are compatible with more browsers. I wasn't able to find a package in the npm index that provided this, but that would be ideal I think.