### PR TITLE
Removed x-is-array dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 
 var extend = require('xtend');
 var EventEmitter = require('eventemitter3');
-var isArray = require('x-is-array');
 
 var _ = require('./util');
 var defaults = {
@@ -92,7 +91,7 @@ function trim(str) {
  * @param {array|string} path
  */
 finder.goTo = function goTo(cfg, data, goToPath) {
-  var path = isArray(goToPath)
+  var path = Array.isArray(goToPath)
     ? goToPath
     : goToPath
         .split('/')
@@ -310,7 +309,7 @@ finder.createColumn = function createColumn(data, cfg, parent) {
 
   if (typeof data === 'function') {
     data.call(null, parent, cfg, callback);
-  } else if (isArray(data)) {
+  } else if (Array.isArray(data)) {
     list = finder.createList(data, cfg);
     div = _.el('div');
     div.appendChild(list);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "finderjs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2156,7 +2156,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2177,12 +2178,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2197,17 +2200,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2324,7 +2330,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2336,6 +2343,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2350,6 +2358,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2357,12 +2366,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2381,6 +2392,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2461,7 +2473,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2473,6 +2486,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2558,7 +2572,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2594,6 +2609,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2613,6 +2629,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2656,12 +2673,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6184,11 +6184,6 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "x-is-array": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
-      "integrity": "sha1-3lIBcdR7P0FvVYfWKbidJrEtwp0="
-    },
     "xhr": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "eventemitter3": "^2.0.3",
-    "x-is-array": "^0.1.0",
     "xtend": "^4.0.0"
   }
 }

--- a/util.js
+++ b/util.js
@@ -4,8 +4,6 @@
  */
 'use strict';
 
-var isArray = require('x-is-array');
-
 /**
  * check if variable is an element
  * @param  {*} potential element
@@ -117,7 +115,7 @@ function addClass(element, className) {
     }
   }
 
-  if (!isArray(className)) {
+  if (!Array.isArray(className)) {
     classNames = className.trim().split(/\s+/);
   }
   classNames.forEach(_addClass.bind(null, element));
@@ -144,7 +142,7 @@ function removeClass(element, className) {
     }
   }
 
-  if (!isArray(className)) {
+  if (!Array.isArray(className)) {
     classNames = className.trim().split(/\s+/);
   }
   classNames.forEach(_removeClass.bind(null, element));
@@ -224,7 +222,7 @@ function first(parent, selector) {
 
 function append(parent, _children) {
   var _frag = frag();
-  var children = isArray(_children) ? _children : [_children];
+  var children = Array.isArray(_children) ? _children : [_children];
 
   children.forEach(_frag.appendChild.bind(_frag));
   parent.appendChild(_frag);


### PR DESCRIPTION
Removed dependency on x-is-array as all browsers support Array.isArray for over a decade (IE9 was release 10 years and 2 days ago). Regenerated dependency files.